### PR TITLE
Fixes typo in legend table

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -55,7 +55,7 @@ const Legend = () =>
             <tr>
                 <td><Rating rating={1} className="inline" /></td>
                 <td>minimal experience</td>
-                <td><Rating rating={5} className="inline" icon="student" /></td>
+                <td><Rating rating={1} className="inline" icon="student" /></td>
                 <td>minimal interest</td>
             </tr>
             <tr>


### PR DESCRIPTION
Hello Oliver!

This just fixes a typo in the star legend. I took a look at the jest snapshots, and it didn't look like this was covered in any of the tests, so I think it should merge fine.

